### PR TITLE
Add retrace server's disclaimer

### DIFF
--- a/config.py
+++ b/config.py
@@ -18,4 +18,4 @@ class Config(object):
     MORE_GABRT = None
     MORE_LR = None
     MORE_SATYR = None
-
+    RS_DELETE_AFTER = 24  # should be read from retrace-servers config

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -31,6 +31,32 @@ body {
     font-size: 37px;
 }
 
+.disclaimer-block {
+  background-color: rgba(120, 120, 120, 0.3);
+  min-height: 250px;
+  margin-bottom: 20px;
+  padding: 15px 15px 0px 15px;
+}
+
+.disclaimer-block p {
+    font-size: 100%;
+    margin-bottom: 2px;
+}
+
+.disclaimer-block h2 {
+    margin-top: 10px;
+    font-size: 28px;
+}
+
+.disclaimer-link {
+    color: white;
+}
+
+.disclaimer-link:hover,
+.disclaimer-link:focus {
+    color: rgba(255, 255, 255, 0.5);
+}
+
 .pre {
   white-space: pre-wrap;
   word-wrap: break-word;
@@ -159,22 +185,26 @@ td > div.progress {
   border-right: 1px solid black;
 }
 
-.wide-panel:nth-child(odd) .single-block p {
+.wide-panel:nth-child(odd) .single-block p,
+.wide-panel:nth-child(odd) .disclaimer-block p {
     color: white;
     margin: 5px 0px 30px 0px;
 }
 
-.wide-panel:nth-child(odd) .single-block h2 {
+.wide-panel:nth-child(odd) .single-block h2,
+.wide-panel:nth-child(odd) .disclaimer-block h2 {
   color: white;
   margin: 5px 0px 15px 0px;
 }
 
-.wide-panel:nth-child(even) .single-block p {
+.wide-panel:nth-child(even) .single-block p,
+.wide-panel:nth-child(even) .disclaimer-block p {
     color: black;
     margin: 5px 0px 15px 0px;
 }
 
-.wide-panel:nth-child(even) .single-block h2 {
+.wide-panel:nth-child(even) .single-block h2,
+.wide-panel:nth-child(even) .disclaimer-block h2 {
   color: black;
   margin: 5px 0px 15px 0px;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,6 +14,9 @@
         <link rel="stylesheet" href="{{url_for('static', filename='css/typeaheadjs.css')}}">
         <link rel="stylesheet" href="{{url_for('static', filename='css/style.css')}}">
 
+        <script src="{{url_for('static', filename='js/jquery.js')}}"></script>
+        <script src="{{url_for('static', filename='js/bootstrap.js')}}"></script>
+
     </head>
     <body>
         <div class="navbar navbar-default navbar-pf">
@@ -84,6 +87,39 @@
                     </div>
                 </div>
             </div>
+            <a data-toggle="collapse" href="#disclaimer" class="disclaimer-link">Click to see retrace server's disclaimer</a>
+
+             <div id="disclaimer" class="collapse">
+                <div class='container'>
+                    <div class="row no-gutters">
+                        <div class="col-md-6 col-lg-6">
+                            <div class="disclaimer-block border-right">
+                                <h2>Keeping your data</h2>
+                                <p>
+                                    Your coredump is only kept on the server while the retrace job is running.
+                                    Once the job is finished, the server keeps retrace log and backtrace.
+                                    All the other data (including coredump) are deleted.
+                                    The retrace log and backtrace are only accessible via unique task ID and password, thus no one (except the author) is allowed to view it.
+                                    All the crash information (including backtrace) is deleted after
+                                    {{config.RS_DELETE_AFTER}} hours of inactivity.
+                                    No possibly private data are kept on the server any longer.
+                                </p>
+                            </div>
+                        </div>
+                        <div class="col-md-6 col-lg-6">
+                            <div class="disclaimer-block">
+                                <h2>Communicating with server</h2>
+                                <p>
+                                    Your coredump is only used for retrace purposes.
+                                    Server administrators are not trying to get your private data from coredumps or backtraces.
+                                    Using a secure communication channel (HTTPS) is strictly recommended.
+                                    Server administrators are not responsible for the problems related to the usage of an insecure channel (such as HTTP).
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+             </div>
         </div>
         <div class="wide-panel">
             <h1>End-user application</h1>


### PR DESCRIPTION
In the original retrace server front page there was a disclaimer.
Since this webpage replaces the original front page provided by retrace
server, we should also display the disclaimer.

Closes abrt/abrt-server-info-page#1

Signed-off-by: Matej Marusak <mmarusak@redhat.com>